### PR TITLE
feat(state): add Zustand store with timer, logging, and refresh

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+import { EventDoc, EventType } from '../core/models'; // use relative import unless you set up tsconfig paths
+import { insertEvent, listEventsToday } from '../db/events.repo.sqlite';
+
+type TimerState = { type: 'sleep' | 'feed'; startedAtMs: number } | undefined;
+
+type Store = {
+  events: EventDoc[];
+  timer: TimerState;
+  refreshToday: () => Promise<void>;
+  logImmediate: (type: Exclude<EventType, 'note' | 'feed'>, meta?: EventDoc['meta']) => Promise<void>;
+  saveNote: (text: string) => Promise<void>;
+  startTimer: (type: 'sleep' | 'feed') => void;
+  stopTimer: () => Promise<void>;
+};
+
+const nowMs = () => Date.now();
+
+export const useStore = create<Store>((set, get) => ({
+  events: [],
+  timer: undefined,
+
+  refreshToday: async () => {
+    const events = await listEventsToday();
+    set({ events });
+  },
+
+  logImmediate: async (type, meta) => {
+    await insertEvent({
+      babyId: 'default',
+      type,
+      tsMs: nowMs(),
+      meta, // forward directly; undefined is fine
+    });
+    await get().refreshToday();
+  },
+
+  saveNote: async (text: string) => {
+    if (!text.trim()) return;
+    await insertEvent({
+      babyId: 'default',
+      type: 'note',
+      tsMs: nowMs(),
+      meta: { noteText: text.trim() },
+    });
+    await get().refreshToday();
+  },
+
+  startTimer: (type) => {
+    const startedAtMs = nowMs();
+    set({ timer: { type, startedAtMs } });
+    if (type === 'sleep') {
+      insertEvent({ babyId: 'default', type: 'sleep', tsMs: startedAtMs })
+        .then(() => get().refreshToday())
+        .catch(() => { /* noop for MVP */ });
+    }
+  },
+
+  stopTimer: async () => {
+    const t = get().timer;
+    if (!t) return;
+
+    if (t.type === 'sleep') {
+      await insertEvent({ babyId: 'default', type: 'wake', tsMs: nowMs() });
+    } else {
+      const durationMs = Math.max(0, nowMs() - t.startedAtMs);
+      await insertEvent({
+        babyId: 'default',
+        type: 'feed',
+        tsMs: nowMs(),
+        meta: { durationMs },
+      });
+    }
+
+    set({ timer: undefined });
+    await get().refreshToday();
+  },
+}));

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -52,7 +52,7 @@ export const useStore = create<Store>((set, get) => ({
     if (type === 'sleep') {
       insertEvent({ babyId: 'default', type: 'sleep', tsMs: startedAtMs })
         .then(() => get().refreshToday())
-        .catch(() => { /* noop for MVP */ });
+        .catch((err) => { console.error('Failed to insert sleep event or refresh:', err); });
     }
   },
 


### PR DESCRIPTION
Adds a central Zustand store to manage baby events and timer state.

Changes

refreshToday → load today’s events from SQLite repo

logImmediate → log diaper/wake events directly

saveNote → log quick note events

startTimer → begin sleep/feed timer (logs a sleep event immediately)

stopTimer → stop timer, log wake or feed with duration

Normalized meta handling (undefined instead of null) to align with EventDoc typing

Notes

No UI changes in this PR

Prepares foundation for wiring into the main screen