### PR TITLE
fix(app): correct entry & router init, wrap with gesture/safe-area, s…

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,10 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": false,
+    "plugins": [
+      "expo-router",
+      "expo-sqlite"
+    ],
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
@@ -16,11 +20,11 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.holtzmano.babyapp",
-      "buildNumber": "1"
+      "buildNumber": "2"
     },
     "android": {
       "package": "com.holtzmano.babyapp",
-      "versionCode": 1,
+      "versionCode": 9,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
@@ -31,6 +35,7 @@
       "favicon": "./assets/favicon.png"
     },
     "extra": {
+      "router": {},
       "eas": {
         "projectId": "c06d0909-2ce8-4069-bef2-df9a28b948ee"
       }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,15 @@
-import { Stack } from "expo-router";
+import { Stack } from 'expo-router';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-/**
- * Root layout for Expo Router navigation stack.
- * Keeps headers hidden globally.
- */
+const screenOptions = { headerShown: false } as const;
+
 export default function RootLayout() {
-  return <Stack screenOptions={SCREEN_OPTIONS} />;
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <Stack screenOptions={screenOptions} />
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
 }
-
-const SCREEN_OPTIONS = { headerShown: false } as const;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -118,23 +118,3 @@ const styles = StyleSheet.create({
   rowNote: { marginTop: 4 },
 });
 
-// import React, { useEffect } from 'react';
-// import { View, Text, Pressable, StyleSheet } from 'react-native';
-
-// export default function IndexScreen() {
-//   useEffect(() => console.log('Index mounted'), []);
-//   return (
-//     <View style={styles.container}>
-//       <Text style={styles.title}>It works 🚀</Text>
-//       <Pressable onPress={() => console.log('Pressed')}>
-//         <Text style={styles.button}>Tap me</Text>
-//       </Pressable>
-//     </View>
-//   );
-// }
-
-// const styles = StyleSheet.create({
-//   container: { flex: 1, backgroundColor: '#0b0b0b', alignItems: 'center', justifyContent: 'center' },
-//   title: { color: 'white', fontSize: 24, marginBottom: 16 },
-//   button: { color: 'white', fontSize: 18, textDecorationLine: 'underline' },
-// });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -117,3 +117,24 @@ const styles = StyleSheet.create({
   rowSub: { color: '#6b7280' },
   rowNote: { marginTop: 4 },
 });
+
+// import React, { useEffect } from 'react';
+// import { View, Text, Pressable, StyleSheet } from 'react-native';
+
+// export default function IndexScreen() {
+//   useEffect(() => console.log('Index mounted'), []);
+//   return (
+//     <View style={styles.container}>
+//       <Text style={styles.title}>It works 🚀</Text>
+//       <Pressable onPress={() => console.log('Pressed')}>
+//         <Text style={styles.button}>Tap me</Text>
+//       </Pressable>
+//     </View>
+//   );
+// }
+
+// const styles = StyleSheet.create({
+//   container: { flex: 1, backgroundColor: '#0b0b0b', alignItems: 'center', justifyContent: 'center' },
+//   title: { color: 'white', fontSize: 24, marginBottom: 16 },
+//   button: { color: 'white', fontSize: 18, textDecorationLine: 'underline' },
+// });

--- a/eas.json
+++ b/eas.json
@@ -1,11 +1,11 @@
 {
-    "cli": { "version": ">= 3.21.0" },
-    "build": {
-      "preview": {
-        "android": { "buildType": "apk" },
-        "ios": { "simulator": false }
-      }
-    },
-    "submit": { "production": {} }
+  "cli": { "version": ">= 3.21.0", "appVersionSource": "remote" },
+  "build": {
+    "preview": { "android": { "buildType": "apk" }, "ios": { "simulator": false } },
+    "dev": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": { "buildType": "apk" }
+    }
   }
-  
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// index.js
+import 'react-native-gesture-handler'; // MUST be first
+import 'expo-router/entry';

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,0 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,19 @@
       "name": "baby-app",
       "version": "1.0.0",
       "dependencies": {
-        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-async-storage/async-storage": "2.1.2",
         "expo": "~53.0.22",
-        "expo-router": "^5.1.4",
-        "expo-sqlite": "^15.2.14",
+        "expo-constants": "~17.1.7",
+        "expo-dev-client": "~5.2.4",
+        "expo-linking": "~7.1.7",
+        "expo-router": "~5.1.5",
+        "expo-sqlite": "~15.2.14",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
-        "react-native": "0.79.6",
-        "react-native-gesture-handler": "^2.28.0",
-        "react-native-safe-area-context": "^5.6.1",
+        "react-native": "0.79.5",
+        "react-native-gesture-handler": "~2.24.0",
+        "react-native-safe-area-context": "5.4.0",
+        "react-native-screens": "~4.11.1",
         "zod": "^4.1.5",
         "zustand": "^5.0.8"
       },
@@ -2346,9 +2350,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
-      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
       "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
@@ -2358,9 +2362,9 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.6.tgz",
-      "integrity": "sha512-UVSP1224PWg0X+mRlZNftV5xQwZGfawhivuW8fGgxNK9MS/U84xZ+16lkqcPh1ank6MOt239lIWHQ1S33CHgqA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
+      "integrity": "sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2503,12 +2507,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.6.tgz",
-      "integrity": "sha512-ZHVst9vByGsegeaddkD2YbZ6NvYb4n3pD9H7Pit94u+NlByq2uBJghoOjT6EKqg+UVl8tLRdi88cU2pDPwdHqA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
+      "integrity": "sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.6",
+        "@react-native/dev-middleware": "0.79.5",
         "chalk": "^4.0.0",
         "debug": "^2.2.0",
         "invariant": "^2.2.4",
@@ -2527,6 +2531,37 @@
         "@react-native-community/cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
+      "integrity": "sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
+      "integrity": "sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.79.5",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^6.2.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
@@ -2554,6 +2589,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/debugger-frontend": {
@@ -2612,18 +2656,18 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.6.tgz",
-      "integrity": "sha512-C5odetI6py3CSELeZEVz+i00M+OJuFZXYnjVD4JyvpLn462GesHRh+Se8mSkU5QSaz9cnpMnyFLJAx05dokWbA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
+      "integrity": "sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.6.tgz",
-      "integrity": "sha512-6wOaBh1namYj9JlCNgX2ILeGUIwc6OP6MWe3Y5jge7Xz9fVpRqWQk88Q5Y9VrAtTMTcxoX3CvhrfRr3tGtSfQw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
+      "integrity": "sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2854,12 +2898,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -2987,51 +3025,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
       }
     },
     "node_modules/anser": {
@@ -4301,6 +4294,74 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-5.2.4.tgz",
+      "integrity": "sha512-s/N/nK5LPo0QZJpV4aPijxyrzV4O49S3dN8D2fljqrX2WwFZzWwFO6dX1elPbTmddxumdcpczsdUPY+Ms8g43g==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "5.1.16",
+        "expo-dev-menu": "6.1.14",
+        "expo-dev-menu-interface": "1.10.0",
+        "expo-manifests": "~0.16.6",
+        "expo-updates-interface": "~1.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-5.1.16.tgz",
+      "integrity": "sha512-tbCske9pvbozaEblyxoyo/97D6od9Ma4yAuyUnXtRET1CKAPKYS+c4fiZ+I3B4qtpZwN3JNFUjG3oateN0y6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.11.0",
+        "expo-dev-menu": "6.1.14",
+        "expo-manifests": "~0.16.6",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-6.1.14.tgz",
+      "integrity": "sha512-yonNMg2GHJZtuisVowdl1iQjZfYP85r1D1IO+ar9D9zlrBPBJhq2XEju52jd1rDmDkmDuEhBSbPNhzIcsBNiPg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "1.10.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
+      "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -4324,6 +4385,12 @@
         "react": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -4339,7 +4406,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-7.1.7.tgz",
       "integrity": "sha512-ZJaH1RIch2G/M3hx2QJdlrKbYFUTOjVVW4g39hfxrE5bPX9xhZUYXqxqQtzMNl1ylAevw9JkgEfWbBWddbZ3UA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~17.1.7",
         "invariant": "^2.2.4"
@@ -4347,6 +4413,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.6.tgz",
+      "integrity": "sha512-1A+do6/mLUWF9xd3uCrlXr9QFDbjbfqAYmUy8UDLOjof1lMrOhyeC4Yi6WexA/A8dhZEpIxSMCKfn7G4aHAh4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~11.0.12",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -4377,12 +4456,13 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-5.1.4.tgz",
-      "integrity": "sha512-8GulCelVN9x+VSOio74K1ZYTG6VyCdJw417gV+M/J8xJOZZTA7rFxAdzujBZZ7jd6aIAG7WEwOUU3oSvUO76Vw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-5.1.5.tgz",
+      "integrity": "sha512-VPhS21DPP+riJIUshs/qpb11L/nzmRK7N7mqSFCr/mjpziznYu/qS+BPeQ88akIuXv6QsXipY5UTfYINdV+P0Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/metro-runtime": "5.0.4",
+        "@expo/schema-utils": "^0.1.0",
         "@expo/server": "^0.6.3",
         "@radix-ui/react-slot": "1.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
@@ -4392,7 +4472,6 @@
         "invariant": "^2.2.4",
         "react-fast-compare": "^3.2.2",
         "react-native-is-edge-to-edge": "^1.1.6",
-        "schema-utils": "^4.0.1",
         "semver": "~7.6.3",
         "server-only": "^0.0.1",
         "shallowequal": "^1.1.0"
@@ -4458,6 +4537,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-updates-interface": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
+      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -4475,22 +4563,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6931,7 +7003,6 @@
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
       "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6946,19 +7017,19 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.6.tgz",
-      "integrity": "sha512-kvIWSmf4QPfY41HC25TR285N7Fv0Pyn3DAEK8qRL9dA35usSaxsJkHfw+VqnonqJjXOaoKCEanwudRAJ60TBGA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
+      "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.6",
-        "@react-native/codegen": "0.79.6",
-        "@react-native/community-cli-plugin": "0.79.6",
-        "@react-native/gradle-plugin": "0.79.6",
-        "@react-native/js-polyfills": "0.79.6",
-        "@react-native/normalize-colors": "0.79.6",
-        "@react-native/virtualized-lists": "0.79.6",
+        "@react-native/assets-registry": "0.79.5",
+        "@react-native/codegen": "0.79.5",
+        "@react-native/community-cli-plugin": "0.79.5",
+        "@react-native/gradle-plugin": "0.79.5",
+        "@react-native/js-polyfills": "0.79.5",
+        "@react-native/normalize-colors": "0.79.5",
+        "@react-native/virtualized-lists": "0.79.5",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -7015,9 +7086,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
-      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
+      "integrity": "sha512-ZdWyOd1C8axKJHIfYxjJKCcxjWEpUtUWgTOVY2wynbiveSQDm8X/PDyAKXSer/GOtIpjudUbACOndZXCN3vHsw==",
       "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
@@ -7040,9 +7111,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
-      "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
+      "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7050,14 +7121,13 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.15.4.tgz",
-      "integrity": "sha512-aKHPDScUbpQiZEG9eZssHdG5jEQs4yiJ8eMx6g81Ex/xU7DZkv3911enzdCb+v4eJE79X8waizY0ZhauZJQmrw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
+      "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
-        "react-native-is-edge-to-edge": "^1.2.1",
+        "react-native-is-edge-to-edge": "^1.1.7",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {
@@ -7065,16 +7135,29 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.6.tgz",
-      "integrity": "sha512-0v2/ruY7eeKun4BeKu+GcfO+SHBdl0LJn4ZFzTzjHdWES0Cn+ONqKljYaIv8p9MV2Hx/kcdEvbY4lWI34jC/mQ==",
-      "license": "MIT"
+    "node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
+      "integrity": "sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "hermes-parser": "0.25.1",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.6.tgz",
-      "integrity": "sha512-khA/Hrbb+rB68YUHrLubfLgMOD9up0glJhw25UE3Kntj32YDyuO0Tqc81ryNTcCekFKJ8XrAaEjcfPg81zBGPw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
+      "integrity": "sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -7440,25 +7523,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
-    },
-    "node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8399,6 +8463,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-latest-callback": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baby-app",
   "version": "1.0.0",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
@@ -9,17 +9,21 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-async-storage/async-storage": "2.1.2",
     "expo": "~53.0.22",
-    "expo-router": "^5.1.4",
-    "expo-sqlite": "^15.2.14",
+    "expo-router": "~5.1.5",
+    "expo-sqlite": "~15.2.14",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.6",
-    "react-native-gesture-handler": "^2.28.0",
-    "react-native-safe-area-context": "^5.6.1",
+    "react-native": "0.79.5",
+    "react-native-gesture-handler": "~2.24.0",
+    "react-native-safe-area-context": "5.4.0",
     "zod": "^4.1.5",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "expo-dev-client": "~5.2.4",
+    "expo-constants": "~17.1.7",
+    "expo-linking": "~7.1.7",
+    "react-native-screens": "~4.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
…tabilize build

- Use root index.js (gesture-handler first, then expo-router/entry)
- Remove stray root index.ts so Metro picks the right entry
- Wrap app with GestureHandlerRootView + SafeAreaProvider
- app.json: plugins [expo-router], newArchEnabled=false; bump android.versionCode
- Add missing peers (expo-constants, expo-linking, react-native-screens)
- Dev: enable Hermes for proper JS Inspector (dev client); align deps
- .gitignore: ignore .expo/ and *.jks