### PR TITLE
Adds DB range querying + meta patching, and small state improvements …

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "typecheck": "tsc --noEmit --project tsconfig.json"
+    "start:clean": "expo start -c",
+    "typecheck": "tsc --noEmit --project tsconfig.json",
+    "doctor": "expo-doctor",
+    "build:dev": "eas build -p android --profile dev",
+    "build:preview": "eas build -p android --profile preview"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.1.2",
@@ -27,6 +31,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3"
   },


### PR DESCRIPTION
Adds DB range querying + meta patching, and small state improvements for a smoother “Today” timeline.

What’s in:

DB

listEventsRange(babyId, fromMs, toMs) — ranged query [>= from, < to].

updateEventMeta(eventId, patch) — JSON meta merge + updated_at_ms.

listEventsToday() now uses an upper bound (< nextDay) via the range API.

State

Tap debounce (700 ms) in logImmediate() to prevent accidental duplicates.

Auto refresh at local midnight via scheduleMidnightRefresh() and a store _init() bootstrap.

Files touched:

src/db/events.repo.sqlite.ts

updateEventMeta(), + listEventsRange()

listEventsToday() updated to use [startOfDay, nextDay).

src/state/store.ts

lastTapAt + TAP_GUARD_MS

scheduleMidnightRefresh() and _init(); debounce inside logImmediate()